### PR TITLE
Here's the implementation for the UM-KM disconnect protocol and KM ex…

### DIFF
--- a/KM-UM/KM/src/includes.h
+++ b/KM-UM/KM/src/includes.h
@@ -3,6 +3,12 @@
 #include <windef.h>
 #include <stdint.h>
 
+// New IOCTL for driver unload
+// Using METHOD_NEITHER and FILE_ANY_ACCESS is typical for simple trigger IOCTLs
+// that don't transfer data and can be called by a privileged user.
+// Function code 0x902 should be unique within this driver's IOCTLs.
+#define IOCTL_REQUEST_UNLOAD_DRIVER CTL_CODE(FILE_DEVICE_UNKNOWN, 0x902, METHOD_NEITHER, FILE_ANY_ACCESS)
+
 #ifndef MEM_IMAGE
 #define MEM_IMAGE    0x1000000
 #endif

--- a/KM-UM/UM/src/StealthComm.h
+++ b/KM-UM/UM/src/StealthComm.h
@@ -23,6 +23,7 @@ enum class CommCommand : uint32_t {
     REQUEST_GET_MODULE_BASE,
     REQUEST_AOB_SCAN,
     REQUEST_ALLOCATE_MEMORY,
+    REQUEST_DISCONNECT, // Added for clean disconnect
 };
 
 enum class SlotStatus : uint32_t {


### PR DESCRIPTION
…plicit unload preparation.

This update introduces two main enhancements:

1.  **Clean UM-KM Disconnect Protocol:**
    *   I added `REQUEST_DISCONNECT` to the `CommCommand` enum in both UM (`StealthComm.h`) and KM (`main.cpp`).
    *   The ImGui application (`Drawing.cpp`) now sends this `REQUEST_DISCONNECT` command to the driver before shutting down its communication components.
    *   The KM driver (`main.cpp`) handles this command in `ProcessSlotRequest` by:
        *   Setting `g_km_thread_should_run = FALSE` to stop the polling work item.
        *   Clearing `g_target_process` (and dereferencing the EPROCESS object after a PID check) and `g_um_shared_comm_block_ptr`.
    This prevents the KM driver from continuing to poll freed UM memory after the client application exits.

2.  **Explicit Driver Unload Mechanism (Kernel-Side Preparation):**
    *   I defined `IOCTL_REQUEST_UNLOAD_DRIVER` in `includes.h`.
    *   I added a handler for this IOCTL in `HandshakeDeviceControl` (`main.cpp`).
    *   I implemented a `PrepareForUnload()` function in `main.cpp` which:
        *   Signals and waits for the discovery thread to terminate.
        *   Stops and frees the polling work item.
        *   Clears UM communication globals and dereferences `g_target_process`.
        *   Clears other handshake-related globals.
    This function quiesces the driver's activities, making it safe for an external tool to request the OS to unload the driver, which would then trigger the existing `DriverUnload` routine. I reviewed the `DriverUnload` routine for idempotency with these changes.

These changes improve the driver's lifecycle management and robustness.