### PR TITLE
Refactor: Implement various stability and performance improvements

### DIFF
--- a/ResponsibleImGui/Source/ImGui Standalone/DriverComm.cpp
+++ b/ResponsibleImGui/Source/ImGui Standalone/DriverComm.cpp
@@ -9,21 +9,22 @@ namespace DriverComm {
 
     DWORD g_pid = 0; // Global PID for this module, set by attach_to_process
 
-    bool attach_to_process(const DWORD pid_to_attach) {
+    NTSTATUS attach_to_process(const DWORD pid_to_attach) { // Returns NTSTATUS
         if (pid_to_attach == 0) {
             std::cerr << "[-] DriverComm::attach_to_process: Invalid PID (0)." << std::endl;
-            return false;
+            return STATUS_INVALID_PARAMETER_1; // Using common NTSTATUS codes
         }
-        if (!StealthComm::InitializeStealthComm()) {
-            std::cerr << "[-] DriverComm::attach_to_process: StealthComm::InitializeStealthComm() failed." << std::endl;
-            return false;
+        // StealthComm::InitializeStealthComm now returns NTSTATUS
+        NTSTATUS status = StealthComm::InitializeStealthComm();
+        if (!NT_SUCCESS(status)) {
+            std::cerr << "[-] DriverComm::attach_to_process: StealthComm::InitializeStealthComm() failed with status 0x" << std::hex << status << std::dec << std::endl;
+            return status;
         }
         DriverComm::g_pid = pid_to_attach;
         #ifdef _DEBUG
         std::cout << "[+] DriverComm::attach_to_process: Successfully initialized StealthComm and attached to PID: " << pid_to_attach << std::endl;
         #endif
-        // Optionally, perform a simple test read or NOP command to confirm KM side is responsive.
-        return true;
+        return STATUS_SUCCESS;
     }
 
     void shutdown() {
@@ -35,68 +36,78 @@ namespace DriverComm {
     }
 
     template <class T>
-    T read_memory(const std::uintptr_t addr) {
-        T temp_buffer = {}; // Initialize to default value (e.g., 0, false, nullptr)
+    NTSTATUS read_memory(const std::uintptr_t addr, T& out_value) {
+        out_value = {}; // Initialize to default
         if (DriverComm::g_pid == 0) {
             #ifdef _DEBUG
-            std::cerr << "[-] DriverComm::read_memory: Not attached to any process (PID is 0). Call attach_to_process first." << std::endl;
+            std::cerr << "[-] DriverComm::read_memory: Not attached (PID is 0)." << std::endl;
             #endif
-            return temp_buffer;
+            return STATUS_INVALID_DEVICE_STATE;
         }
         if (addr == 0) {
             #ifdef _DEBUG
             std::cerr << "[-] DriverComm::read_memory: Attempted to read from NULL address." << std::endl;
             #endif
-            return temp_buffer;
+            return STATUS_INVALID_PARAMETER_1; // Address is param 1
         }
 
         size_t bytes_read = 0;
-        if (!StealthComm::ReadMemory(DriverComm::g_pid, addr, &temp_buffer, sizeof(T), &bytes_read)) {
+        NTSTATUS status = StealthComm::ReadMemory(DriverComm::g_pid, addr, &out_value, sizeof(T), &bytes_read);
+
+        if (!NT_SUCCESS(status)) {
+            // StealthComm::ReadMemory already logs its errors.
+            // Log DriverComm specific context if needed.
             #ifdef _DEBUG
-            // StealthComm::ReadMemory might already log, but a DriverComm level log can be useful.
-            // std::cerr << "[-] DriverComm::read_memory: StealthComm::ReadMemory failed for address 0x" << std::hex << addr << std::dec << std::endl;
+            // std::cerr << "[-] DriverComm::read_memory: StealthComm::ReadMemory failed for address 0x" << std::hex << addr << " with status 0x" << status << std::dec << std::endl;
             #endif
-            // Return default-initialized buffer on failure
-        } else if (bytes_read != sizeof(T)) {
+            RtlZeroMemory(&out_value, sizeof(T)); // Zero out on failure
+            return status;
+        }
+
+        if (bytes_read != sizeof(T)) {
             #ifdef _DEBUG
             std::cerr << "[-] DriverComm::read_memory: Read size mismatch for address 0x" << std::hex << addr
                       << std::dec << ". Expected " << sizeof(T) << ", Got " << bytes_read << std::endl;
             #endif
-            // Partial read or error, return default-initialized buffer
-            RtlZeroMemory(&temp_buffer, sizeof(T)); // Zero out on partial read for safety
+            RtlZeroMemory(&out_value, sizeof(T)); // Zero out on partial read for safety
+            return STATUS_PARTIAL_COPY; // Or a more specific error
         }
-        return temp_buffer;
+        return STATUS_SUCCESS;
     }
 
     template <class T>
-    bool write_memory(const std::uintptr_t addr, const T& value) {
+    NTSTATUS write_memory(const std::uintptr_t addr, const T& value) {
         if (DriverComm::g_pid == 0) {
             #ifdef _DEBUG
-            std::cerr << "[-] DriverComm::write_memory: Not attached to any process (PID is 0). Call attach_to_process first." << std::endl;
+            std::cerr << "[-] DriverComm::write_memory: Not attached (PID is 0)." << std::endl;
             #endif
-            return false;
+            return STATUS_INVALID_DEVICE_STATE;
         }
          if (addr == 0) {
             #ifdef _DEBUG
             std::cerr << "[-] DriverComm::write_memory: Attempted to write to NULL address." << std::endl;
             #endif
-            return false;
+            return STATUS_INVALID_PARAMETER_1;
         }
 
         size_t bytes_written = 0;
-        bool success = StealthComm::WriteMemory(DriverComm::g_pid, addr, &value, sizeof(T), &bytes_written);
-        if (!success) {
-             #ifdef _DEBUG
-            // std::cerr << "[-] DriverComm::write_memory: StealthComm::WriteMemory failed for address 0x" << std::hex << addr << std::dec << std::endl;
+        NTSTATUS status = StealthComm::WriteMemory(DriverComm::g_pid, addr, &value, sizeof(T), &bytes_written);
+
+        if (!NT_SUCCESS(status)) {
+            #ifdef _DEBUG
+            // std::cerr << "[-] DriverComm::write_memory: StealthComm::WriteMemory failed for address 0x" << std::hex << addr << " with status 0x" << status << std::dec << std::endl;
             #endif
-        } else if (bytes_written != sizeof(T)) {
+            return status;
+        }
+
+        if (bytes_written != sizeof(T)) {
             #ifdef _DEBUG
             std::cerr << "[-] DriverComm::write_memory: Write size mismatch for address 0x" << std::hex << addr
                       << std::dec << ". Expected " << sizeof(T) << ", Wrote " << bytes_written << std::endl;
             #endif
-            return false; // Indicate error on partial write
+            return STATUS_PARTIAL_COPY; // Indicate error on partial write
         }
-        return success && (bytes_written == sizeof(T));
+        return STATUS_SUCCESS;
     }
 
     // Explicit instantiations
@@ -106,156 +117,157 @@ namespace DriverComm {
     template bool write_memory<double>(const std::uintptr_t addr, const double& value);
     template bool write_memory<uint8_t>(const std::uintptr_t addr, const uint8_t& value);
     template bool write_memory<uint16_t>(const std::uintptr_t addr, const uint16_t& value);
-    template bool write_memory<uint32_t>(const std::uintptr_t addr, const uint32_t& value);
-    template bool write_memory<uint64_t>(const std::uintptr_t addr, const uint64_t& value);
-    // Example for pointer types if used, though less common for generic T like this
-    // template bool write_memory<void*>(const std::uintptr_t addr, void* const& value);
+    template NTSTATUS write_memory<bool>(const std::uintptr_t addr, const bool& value);
+    template NTSTATUS write_memory<int>(const std::uintptr_t addr, const int& value);
+    template NTSTATUS write_memory<float>(const std::uintptr_t addr, const float& value);
+    template NTSTATUS write_memory<double>(const std::uintptr_t addr, const double& value);
+    template NTSTATUS write_memory<uint8_t>(const std::uintptr_t addr, const uint8_t& value);
+    template NTSTATUS write_memory<uint16_t>(const std::uintptr_t addr, const uint16_t& value);
+    template NTSTATUS write_memory<uint32_t>(const std::uintptr_t addr, const uint32_t& value);
+    template NTSTATUS write_memory<uint64_t>(const std::uintptr_t addr, const uint64_t& value);
+    // template NTSTATUS write_memory<void*>(const std::uintptr_t addr, void* const& value);
+
+    template NTSTATUS read_memory<int>(const std::uintptr_t addr, int& out_value);
+    template NTSTATUS read_memory<float>(const std::uintptr_t addr, float& out_value);
+    template NTSTATUS read_memory<double>(const std::uintptr_t addr, double& out_value);
+    template NTSTATUS read_memory<bool>(const std::uintptr_t addr, bool& out_value);
+    template NTSTATUS read_memory<uint8_t>(const std::uintptr_t addr, uint8_t& out_value);
+    template NTSTATUS read_memory<uint16_t>(const std::uintptr_t addr, uint16_t& out_value);
+    template NTSTATUS read_memory<uint32_t>(const std::uintptr_t addr, uint32_t& out_value);
+    template NTSTATUS read_memory<uint64_t>(const std::uintptr_t addr, uint64_t& out_value);
+    // template NTSTATUS read_memory<void*>(const std::uintptr_t addr, void*& out_value);
 
 
-    template int read_memory<int>(const std::uintptr_t addr);
-    template float read_memory<float>(const std::uintptr_t addr);
-    template double read_memory<double>(const std::uintptr_t addr);
-    template bool read_memory<bool>(const std::uintptr_t addr);
-    template uint8_t read_memory<uint8_t>(const std::uintptr_t addr);
-    template uint16_t read_memory<uint16_t>(const std::uintptr_t addr);
-    template uint32_t read_memory<uint32_t>(const std::uintptr_t addr);
-    template uint64_t read_memory<uint64_t>(const std::uintptr_t addr);
-    // Example for pointer types
-    // template void* read_memory<void*>(const std::uintptr_t addr);
-
-
-    bool allocate_memory(DWORD pid_arg, SIZE_T size, uintptr_t& out_address, PVOID allocHint) {
-        if (pid_arg == 0 && DriverComm::g_pid == 0) { // Allow passing PID or using global
-             std::cerr << "[-] DriverComm::allocate_memory: PID not set and not provided." << std::endl;
-            return false;
+    // New NTSTATUS returning function
+    NTSTATUS allocate_memory_ex(DWORD pid, SIZE_T size, uintptr_t& out_address, PVOID allocHint) {
+        out_address = 0;
+        DWORD target_pid_to_use = (pid != 0) ? pid : DriverComm::g_pid;
+        if (target_pid_to_use == 0) {
+            std::cerr << "[-] DriverComm::allocate_memory_ex: PID not set and not provided." << std::endl;
+            return STATUS_INVALID_PARAMETER; // Or STATUS_INVALID_DEVICE_STATE
         }
-        DWORD target_pid_to_use = (pid_arg != 0) ? pid_arg : DriverComm::g_pid;
-
+        // StealthComm::AllocateMemory returns uintptr_t (0 on error), not NTSTATUS directly.
+        // We need to infer NTSTATUS or modify StealthComm::AllocateMemory.
+        // For now, assume 0 means failure from StealthComm::AllocateMemory.
         out_address = StealthComm::AllocateMemory(static_cast<uint64_t>(target_pid_to_use), size, reinterpret_cast<uintptr_t>(allocHint));
         if (out_address != 0) {
-            #ifdef _DEBUG
-            // StealthComm logs this, so DriverComm might not need to.
-            // std::cout << "[+] DriverComm::allocate_memory: Allocated " << size << " bytes at: 0x" << std::hex << out_address << " for PID " << target_pid_to_use << std::dec << std::endl;
-            #endif
-            return true;
+            return STATUS_SUCCESS;
+        } else {
+            // StealthComm::AllocateMemory already logs.
+            return STATUS_NO_MEMORY; // Generic failure if StealthComm returned 0
         }
-        #ifdef _DEBUG
-        // std::cerr << "[-] DriverComm::allocate_memory: Failed to allocate memory for PID " << target_pid_to_use << "." << std::endl;
-        #endif
-        return false;
+    }
+    // Old compatible function
+    bool allocate_memory(DWORD pid_arg, SIZE_T size, uintptr_t& out_address, PVOID allocHint) {
+        return NT_SUCCESS(allocate_memory_ex(pid_arg, size, out_address, allocHint));
     }
 
+
+    NTSTATUS get_module_base_info(DWORD pid, const wchar_t* module_name, uintptr_t& out_base_address) {
+        out_base_address = 0;
+        DWORD target_pid_to_use = (pid != 0) ? pid : DriverComm::g_pid;
+        if (target_pid_to_use == 0) {
+            std::cerr << "[-] DriverComm::get_module_base_info: PID not set and not provided." << std::endl;
+            return STATUS_INVALID_PARAMETER;
+        }
+        // StealthComm::GetModuleBase returns uintptr_t (0 on error)
+        out_base_address = StealthComm::GetModuleBase(static_cast<uint64_t>(target_pid_to_use), module_name);
+        if (out_base_address == 0) {
+            // StealthComm::GetModuleBase logs more detailed errors internally.
+            // Return a general error; could be STATUS_NOT_FOUND or other from underlying calls.
+            return STATUS_NOT_FOUND; // Or map from a StealthComm error if it provided one
+        }
+        return STATUS_SUCCESS;
+    }
+    // Old compatible function
     uintptr_t GetModuleBase(DWORD pid_arg, const wchar_t* module_name) {
-         if (pid_arg == 0 && DriverComm::g_pid == 0) {
-            std::cerr << "[-] DriverComm::GetModuleBase: PID not set and not provided." << std::endl;
-            return 0;
-        }
-        DWORD target_pid_to_use = (pid_arg != 0) ? pid_arg : DriverComm::g_pid;
-        uintptr_t base = StealthComm::GetModuleBase(static_cast<uint64_t>(target_pid_to_use), module_name);
-        // if (base == 0) {
-        //     #ifdef _DEBUG
-        //     std::wcerr << L"[-] DriverComm::GetModuleBase: Failed to get base for module '" << module_name << L"' in PID " << target_pid_to_use << std::endl;
-        //     #endif
-        // }
-        return base;
+        uintptr_t base_addr = 0;
+        get_module_base_info(pid_arg, module_name, base_addr);
+        return base_addr; // Returns 0 on failure
     }
 
+
+    NTSTATUS aob_scan_info(DWORD pid_to_use, uintptr_t startAddress, SIZE_T regionSize, const char* pattern, const char* mask, uintptr_t& out_found_address) {
+        out_found_address = 0;
+        DWORD target_pid_to_use_final = (pid_to_use != 0) ? pid_to_use : DriverComm::g_pid;
+        if (target_pid_to_use_final == 0) {
+            std::cerr << "[-] DriverComm::aob_scan_info: PID not set." << std::endl;
+            return STATUS_INVALID_PARAMETER;
+        }
+        // StealthComm::AobScan returns uintptr_t (0 on error/not found)
+        out_found_address = StealthComm::AobScan(target_pid_to_use_final, startAddress, regionSize, pattern, mask, nullptr, 0);
+        if (out_found_address == 0) {
+            // StealthComm::AobScan logs.
+            return STATUS_NOT_FOUND; // Or a more specific error if StealthComm could provide one
+        }
+        return STATUS_SUCCESS;
+    }
+    // Old compatible function
     uintptr_t AOBScan(uintptr_t startAddress, SIZE_T regionSize, const char* pattern, const char* mask) {
-        if (DriverComm::g_pid == 0) {
-            std::cerr << "[-] DriverComm::AOBScan: PID not set. Call attach_to_process first." << std::endl;
-            return 0;
-        }
-        uintptr_t result_addr = StealthComm::AobScan(DriverComm::g_pid, startAddress, regionSize, pattern, mask, nullptr, 0);
-        // if (result_addr == 0) {
-        //     #ifdef _DEBUG
-        //     std::cerr << "[-] DriverComm::AOBScan: Pattern not found. Start: 0x" << std::hex << startAddress << ", Size: " << regionSize << ", Pattern: " << pattern << std::dec << std::endl;
-        //     #endif
-        // }
-        return result_addr;
+        uintptr_t found_addr = 0;
+        aob_scan_info(DriverComm::g_pid, startAddress, regionSize, pattern, mask, found_addr);
+        return found_addr; // Returns 0 on failure
     }
 
-    bool read_memory_buffer(const std::uintptr_t addr, void* buffer, SIZE_T size) {
+
+    NTSTATUS read_memory_buffer(const std::uintptr_t addr, void* buffer, SIZE_T size, SIZE_T* out_bytes_read) {
+        if (out_bytes_read) *out_bytes_read = 0;
         if (DriverComm::g_pid == 0) {
-            #ifdef _DEBUG
-            std::cerr << "[-] DriverComm::read_memory_buffer: Not attached to any process (PID is 0)." << std::endl;
-            #endif
-            return false;
+            return STATUS_INVALID_DEVICE_STATE;
         }
         if (addr == 0) {
-            #ifdef _DEBUG
-            std::cerr << "[-] DriverComm::read_memory_buffer: Attempted to read from NULL address." << std::endl;
-            #endif
-            return false;
+            return STATUS_INVALID_PARAMETER_1;
         }
         if (!buffer) {
-            #ifdef _DEBUG
-            std::cerr << "[-] DriverComm::read_memory_buffer: Output buffer is null." << std::endl;
-            #endif
-            return false;
+            return STATUS_INVALID_PARAMETER_2;
         }
         if (size == 0) {
-            return true; // Nothing to read
+            return STATUS_SUCCESS; // Nothing to read
         }
-
-        // Directly use StealthComm::ReadMemory for the whole buffer
-        size_t bytes_read = 0;
-        if (!StealthComm::ReadMemory(DriverComm::g_pid, addr, buffer, size, &bytes_read)) {
-            #ifdef _DEBUG
-            // StealthComm::ReadMemory likely logs errors, but high-level one is good.
-            std::cerr << "[-] DriverComm::read_memory_buffer: StealthComm::ReadMemory failed for address 0x" << std::hex << addr << std::dec << ", size " << size << "." << std::endl;
-            #endif
-            return false;
-        }
-        if (bytes_read != size) {
-            #ifdef _DEBUG
-            std::cerr << "[-] DriverComm::read_memory_buffer: Read size mismatch for address 0x" << std::hex << addr
-                      << std::dec << ". Expected " << size << ", Got " << bytes_read << "." << std::endl;
-            #endif
-            return false; // Partial read is considered a failure for buffer operation
-        }
-        return true;
+        // StealthComm::ReadMemory now returns NTSTATUS
+        return StealthComm::ReadMemory(DriverComm::g_pid, addr, buffer, size, out_bytes_read);
     }
 
-    bool write_memory_buffer(const std::uintptr_t addr, const void* buffer, SIZE_T size) {
+    NTSTATUS write_memory_buffer(const std::uintptr_t addr, const void* buffer, SIZE_T size, SIZE_T* out_bytes_written) {
+        if (out_bytes_written) *out_bytes_written = 0;
         if (DriverComm::g_pid == 0) {
-            #ifdef _DEBUG
-            std::cerr << "[-] DriverComm::write_memory_buffer: Not attached to any process (PID is 0)." << std::endl;
-            #endif
-            return false;
+            return STATUS_INVALID_DEVICE_STATE;
         }
         if (addr == 0) {
-            #ifdef _DEBUG
-            std::cerr << "[-] DriverComm::write_memory_buffer: Attempted to write to NULL address." << std::endl;
-            #endif
-            return false;
+            return STATUS_INVALID_PARAMETER_1;
         }
         if (!buffer) {
-            #ifdef _DEBUG
-            std::cerr << "[-] DriverComm::write_memory_buffer: Input buffer is null." << std::endl;
-            #endif
-            return false;
+            return STATUS_INVALID_PARAMETER_2;
         }
         if (size == 0) {
-            return true; // Nothing to write
+            return STATUS_SUCCESS; // Nothing to write
         }
+        // StealthComm::WriteMemory now returns NTSTATUS
+        return StealthComm::WriteMemory(DriverComm::g_pid, addr, buffer, size, out_bytes_written);
+    }
 
-        // Directly use StealthComm::WriteMemory for the whole buffer
-        size_t bytes_written = 0;
-        if (!StealthComm::WriteMemory(DriverComm::g_pid, addr, buffer, size, &bytes_written)) {
-            #ifdef _DEBUG
-            // StealthComm::WriteMemory likely logs errors.
-            std::cerr << "[-] DriverComm::write_memory_buffer: StealthComm::WriteMemory failed for address 0x" << std::hex << addr << std::dec << ", size " << size << "." << std::endl;
-            #endif
-            return false;
+    NTSTATUS free_memory_ex(DWORD pid, uintptr_t address, SIZE_T size) {
+        DWORD target_pid_to_use = (pid != 0) ? pid : DriverComm::g_pid;
+        if (target_pid_to_use == 0) {
+            std::cerr << "[-] DriverComm::free_memory_ex: PID not set." << std::endl;
+            return STATUS_INVALID_PARAMETER;
         }
-        if (bytes_written != size) {
-            #ifdef _DEBUG
-            std::cerr << "[-] DriverComm::write_memory_buffer: Write size mismatch for address 0x" << std::hex << addr
-                      << std::dec << ". Expected " << size << ", Wrote " << bytes_written << "." << std::endl;
-            #endif
-            return false; // Partial write is considered a failure
+        if (address == 0) {
+            std::cerr << "[-] DriverComm::free_memory_ex: Address cannot be zero." << std::endl;
+            return STATUS_INVALID_PARAMETER_2;
         }
-        return true;
+        // StealthComm::FreeMemory now returns NTSTATUS
+        NTSTATUS status = StealthComm::FreeMemory(static_cast<uint64_t>(target_pid_to_use), address, size);
+        if (!NT_SUCCESS(status)) {
+            #ifdef _DEBUG
+            std::cerr << "[-] DriverComm::free_memory_ex: StealthComm::FreeMemory failed for address 0x" << std::hex << address << " with status 0x" << status << std::dec << std::endl;
+            #endif
+        }
+        return status;
+    }
+    // Old compatible function
+    bool free_memory(uintptr_t address, SIZE_T size) {
+        return NT_SUCCESS(free_memory_ex(DriverComm::g_pid, address, size));
     }
 
 } // namespace DriverComm

--- a/ResponsibleImGui/Source/ImGui Standalone/DriverComm.h
+++ b/ResponsibleImGui/Source/ImGui Standalone/DriverComm.h
@@ -19,31 +19,46 @@ namespace DriverComm {
 
     // Attempts to initialize communication with the driver and sets the target process.
     // This should be called before any other DriverComm functions.
-    bool attach_to_process(const DWORD pid);
+    // Returns NTSTATUS for more detailed error information.
+    NTSTATUS attach_to_process(const DWORD pid);
 
     // Shuts down communication with the driver.
     void shutdown();
 
+    // Returns NTSTATUS. Data is returned via 'out_value'.
     template <class T>
-    T read_memory(const std::uintptr_t addr);
+    NTSTATUS read_memory(const std::uintptr_t addr, T& out_value);
 
+    // Returns NTSTATUS.
     template <class T>
-    bool write_memory(const std::uintptr_t addr, const T& value);
+    NTSTATUS write_memory(const std::uintptr_t addr, const T& value);
 
-    bool read_memory_buffer(const std::uintptr_t addr, void* buffer, SIZE_T size);
-    bool write_memory_buffer(const std::uintptr_t addr, const void* buffer, SIZE_T size);
+    // Returns NTSTATUS.
+    NTSTATUS read_memory_buffer(const std::uintptr_t addr, void* buffer, SIZE_T size, SIZE_T* out_bytes_read = nullptr);
+    NTSTATUS write_memory_buffer(const std::uintptr_t addr, const void* buffer, SIZE_T size, SIZE_T* out_bytes_written = nullptr);
 
-    // Gets the base address of a module in the specified process.
+    // Returns NTSTATUS. Base address is returned via 'out_base_address'.
+    NTSTATUS get_module_base_info(DWORD pid, const wchar_t* module_name, uintptr_t& out_base_address);
+    // Retain old GetModuleBase for compatibility if direct uintptr_t return is preferred in some places,
+    // but it will internally call get_module_base_info and handle status.
     uintptr_t GetModuleBase(DWORD pid, const wchar_t* module_name);
 
-    // Performs an Array of Bytes (AOB) scan in the target process.
-    // Returns the address of the found pattern, or nullptr if not found.
-    // mask parameter is currently not used by underlying StealthComm::AobScan.
+
+    // Returns NTSTATUS. Found address is returned via 'out_found_address'.
+    NTSTATUS aob_scan_info(DWORD pid_to_use, uintptr_t startAddress, SIZE_T regionSize, const char* pattern, const char* mask, uintptr_t& out_found_address);
+    // Retain old AOBScan for compatibility.
     uintptr_t AOBScan(uintptr_t startAddress, SIZE_T regionSize, const char* pattern, const char* mask);
 
-    // Allocates memory in the target process.
-    // out_address will contain the base address of the allocated memory on success.
-    // allocHint is an optional address to guide where memory should be allocated.
+
+    // Returns NTSTATUS. Allocated address is returned via 'out_address'.
+    NTSTATUS allocate_memory_ex(DWORD pid, SIZE_T size, uintptr_t& out_address, PVOID allocHint = nullptr);
+    // Retain old allocate_memory for compatibility.
     bool allocate_memory(DWORD pid, SIZE_T size, uintptr_t& out_address, PVOID allocHint = nullptr);
+
+
+    // Returns NTSTATUS.
+    NTSTATUS free_memory_ex(DWORD pid, uintptr_t address, SIZE_T size);
+    // Retain old free_memory for compatibility
+    bool free_memory(uintptr_t address, SIZE_T size);
 
 }

--- a/ResponsibleImGui/Source/ImGui Standalone/Features.h
+++ b/ResponsibleImGui/Source/ImGui Standalone/Features.h
@@ -15,6 +15,7 @@
 #include <iostream>
 #include <thread>
 #include <chrono>
+#include <atomic> // Added for std::atomic
 
 #include "Logging.h" // Added for logging functions
 #include "ImGui/imgui_custom.h"
@@ -27,6 +28,8 @@ using json = nlohmann::json;
 // Global state
 inline std::unordered_map<std::string, bool> FeatureConfig;
 inline std::unordered_map<std::string, int> Hotkeys;
+inline std::atomic<bool> g_aob_scan_complete_flag{false};
+inline std::atomic<bool> g_aob_scan_running{false};
 
 // Forward declarations for helper functions
 void LoadHotkeys();
@@ -36,74 +39,100 @@ std::string GetKeyName(int vkCode);
 bool DrawHotkeyPicker(const std::string& name, const std::string& label, bool& listening);
 std::vector<BYTE> HexToBytes(const std::string& hex_str);
 
-// Modified InjectCodecave to accept vector of bytes
-inline bool InjectCodecave(
+// Modified InjectCodecave to use NTSTATUS and atomic<uintptr_t>
+inline bool InjectCodecave( // Return bool for simplicity in feature logic, but use NTSTATUS internally
     DWORD pid,
     uintptr_t targetAddress,
-    const std::vector<BYTE>& shellcodeBytes, // Changed from hex string to byte vector
+    const std::vector<BYTE>& shellcodeBytes,
     SIZE_T originalSize,
-    uintptr_t& codecaveAddress)
+    std::atomic<uintptr_t>& codecaveAddress_atomic) // Takes atomic by reference
 {
     if (shellcodeBytes.empty()) {
         LogMessage("[-] InjectCodecave: Shellcode byte vector is empty.");
-        return FALSE;
+        return false; // Changed from FALSE
     }
-    if (shellcodeBytes.size() < 5 && originalSize > 0) {
+    if (shellcodeBytes.size() < 5 && originalSize > 0) { // Need 5 bytes for a JMP
         LogMessage("[-] InjectCodecave: Shellcode must be at least 5 bytes for a JMP if originalSize > 0.");
-        return FALSE;
+        return false;
     }
 
     std::vector<BYTE> finalShellcode = shellcodeBytes;
+    uintptr_t currentCodecaveAddressVal = codecaveAddress_atomic.load();
 
-    if (codecaveAddress == 0) {
-        if (!DriverComm::allocate_memory(pid, finalShellcode.size() + 32, codecaveAddress, reinterpret_cast<PVOID>(targetAddress))) {
-            LogMessageF("[-] InjectCodecave: DriverComm::allocate_memory failed for codecave. PID: %lu, Size: %zu", pid, finalShellcode.size() + 32);
-            return FALSE;
+    if (currentCodecaveAddressVal == 0) {
+        NTSTATUS alloc_status = DriverComm::allocate_memory_ex(pid, finalShellcode.size() + 32, currentCodecaveAddressVal, reinterpret_cast<PVOID>(targetAddress));
+        if (!NT_SUCCESS(alloc_status)) {
+            LogMessageF("[-] InjectCodecave: DriverComm::allocate_memory_ex failed. PID: %lu, Size: %zu, Status: 0x%lX", pid, finalShellcode.size() + 32, alloc_status);
+            return false;
         }
+        codecaveAddress_atomic.store(currentCodecaveAddressVal);
         #ifdef _DEBUG
-        std::cout << "[+] InjectCodecave: Codecave allocated at: 0x" << std::hex << codecaveAddress << std::dec << " for PID " << pid << std::endl;
+        std::cout << "[+] InjectCodecave: Codecave allocated at: 0x" << std::hex << currentCodecaveAddressVal << std::dec << " for PID " << pid << std::endl;
         #endif
     } else {
         #ifdef _DEBUG
-        std::cout << "[+] InjectCodecave: Using provided codecave address: 0x" << std::hex << codecaveAddress << std::dec << " for PID " << pid << std::endl;
+        std::cout << "[+] InjectCodecave: Using provided codecave address: 0x" << std::hex << currentCodecaveAddressVal << std::dec << " for PID " << pid << std::endl;
         #endif
     }
 
     if (originalSize > 0) {
         if (finalShellcode.size() < 5) {
              LogMessageF("[-] InjectCodecave: Shellcode (size %zu) is too small to append a 5-byte jump.", finalShellcode.size());
-             return FALSE;
+             return false;
         }
         SIZE_T jmpPatchOffset = finalShellcode.size() - 5;
-        finalShellcode[jmpPatchOffset] = 0xE9;
-        DWORD returnRelativeOffset = static_cast<DWORD>((targetAddress + originalSize) - (codecaveAddress + jmpPatchOffset + 5));
+        finalShellcode[jmpPatchOffset] = 0xE9; // JMP rel32
+        DWORD returnRelativeOffset = static_cast<DWORD>((targetAddress + originalSize) - (currentCodecaveAddressVal + jmpPatchOffset + 5));
         memcpy(&finalShellcode[jmpPatchOffset + 1], &returnRelativeOffset, sizeof(returnRelativeOffset));
     }
 
-    if (!DriverComm::write_memory_buffer(codecaveAddress, finalShellcode.data(), finalShellcode.size())) {
-        LogMessageF("[-] InjectCodecave: DriverComm::write_memory for codecave failed at 0x%llX. PID: %lu", codecaveAddress, pid);
-        return FALSE;
+    NTSTATUS write_sc_status = DriverComm::write_memory_buffer(currentCodecaveAddressVal, finalShellcode.data(), finalShellcode.size());
+    if (!NT_SUCCESS(write_sc_status)) {
+        LogMessageF("[-] InjectCodecave: DriverComm::write_memory_buffer for codecave failed at 0x%llX. PID: %lu, Status: 0x%lX", currentCodecaveAddressVal, pid, write_sc_status);
+        return false;
     }
     #ifdef _DEBUG
-    std::cout << "[+] InjectCodecave: Shellcode (size " << finalShellcode.size() << ") written to codecave at 0x" << std::hex << codecaveAddress << std::dec << " for PID " << pid << std::endl;
+    std::cout << "[+] InjectCodecave: Shellcode (size " << finalShellcode.size() << ") written to codecave at 0x" << std::hex << currentCodecaveAddressVal << std::dec << " for PID " << pid << std::endl;
     #endif
 
     if (originalSize > 0) {
         std::vector<BYTE> patchBytes(originalSize, 0x90);
-        patchBytes[0] = 0xE9;
-        DWORD jumpToCaveRelativeOffset = static_cast<DWORD>(codecaveAddress - (targetAddress + 5));
+        patchBytes[0] = 0xE9; // JMP rel32
+        DWORD jumpToCaveRelativeOffset = static_cast<DWORD>(currentCodecaveAddressVal - (targetAddress + 5));
         memcpy(&patchBytes[1], &jumpToCaveRelativeOffset, sizeof(jumpToCaveRelativeOffset));
 
-        if (!DriverComm::write_memory_buffer(targetAddress, patchBytes.data(), patchBytes.size())) {
-            LogMessageF("[-] InjectCodecave: DriverComm::write_memory for hook at 0x%llX. PID: %lu failed.", targetAddress, pid);
-            return FALSE;
+        NTSTATUS write_hook_status = DriverComm::write_memory_buffer(targetAddress, patchBytes.data(), patchBytes.size());
+        if (!NT_SUCCESS(write_hook_status)) {
+            LogMessageF("[-] InjectCodecave: DriverComm::write_memory_buffer for hook at 0x%llX. PID: %lu failed. Status: 0x%lX", targetAddress, pid, write_hook_status);
+            return false;
         }
         #ifdef _DEBUG
         std::cout << "[+] InjectCodecave: Hook (JMP to cave) written to 0x" << std::hex << targetAddress << std::dec << " for PID " << pid << std::endl;
         #endif
     }
-    return TRUE;
+    return true; // Changed from TRUE
 }
+
+// Function to release a codecave
+static inline void ReleaseCodecave(DWORD pid, std::atomic<uintptr_t>& featureCodecaveAddress, bool& memAllocatedFlag) {
+    uintptr_t address_to_free = featureCodecaveAddress.load();
+    if (address_to_free != 0 && memAllocatedFlag) {
+        NTSTATUS free_status = DriverComm::free_memory_ex(pid, address_to_free, 0); // Size 0 for MEM_RELEASE
+        if (NT_SUCCESS(free_status)) {
+            LogMessageF("[+] Codecave at 0x%llX freed successfully for PID %lu.", address_to_free, pid);
+            featureCodecaveAddress.store(0);
+            memAllocatedFlag = false;
+        } else {
+            LogMessageF("[-] Failed to free codecave at 0x%llX for PID %lu. Status: 0x%lX", address_to_free, pid, free_status);
+            // Don't reset flags if free failed, might retry or indicates an issue.
+        }
+    } else if (address_to_free != 0 && !memAllocatedFlag) {
+        // This case could happen if address was set but memAllocatedFlag is false (e.g. shared cave not owned by this feature)
+        // For now, we only free if memAllocatedFlag indicates this feature instance allocated it.
+        // LogMessageF("[!] ReleaseCodecave: Address 0x%llX present but memAllocatedFlag is false. Not freeing.", address_to_free);
+    }
+}
+
 
 // Hotkey and config helpers
 inline std::filesystem::path GetHotkeysFilePath() { char* userProfile = nullptr; size_t len = 0; if (_dupenv_s(&userProfile, &len, "USERPROFILE") != 0 || !userProfile) { return std::filesystem::current_path() / "hotkeys.json"; } std::filesystem::path docs = std::filesystem::path(userProfile) / "Documents"; free(userProfile); std::filesystem::path hotkeysDir = docs / "Hatemob" / "Hotkeys"; std::error_code ec; std::filesystem::create_directories(hotkeysDir, ec); if(ec) { LogMessageF("[-] GetHotkeysFilePath: Error creating directory %s: %s", hotkeysDir.string().c_str(), ec.message().c_str());} return hotkeysDir / "hotkeys.json";}
@@ -115,51 +144,114 @@ inline bool DrawHotkeyPicker(const std::string& name, const std::string& label, 
 inline std::vector<BYTE> HexToBytes(const std::string& hex_str) { std::vector<BYTE> bytes; std::string hex = hex_str; hex.erase(std::remove_if(hex.begin(), hex.end(), ::isspace), hex.end()); if (hex.length() % 2 != 0) {LogMessage("[-] HexToBytes: Odd length hex string."); return bytes; } if (hex.empty()){ return bytes; } for (size_t i = 0; i < hex.length(); i += 2) { std::string byteString = hex.substr(i, 2); try { BYTE byte = static_cast<BYTE>(std::stoul(byteString, nullptr, 16)); bytes.push_back(byte); } catch (const std::exception& e) {LogMessageF("[-] HexToBytes: Error parsing '%s': %s", byteString.c_str(), e.what()); bytes.clear(); return bytes; } } return bytes; }
 
 // Feature Namespaces
-namespace Killaura { bool Enabled = false; bool mem_allocated = false; uintptr_t memAllocatedAddress = 0; std::string AOB = "F3 0F 10 41 20 32 C0 0F C6 C0 ? 0F 11 02 C3 ? 0F ? ? ? 32"; std::string shellcode_hex = "c7 41 20 00 00 7a 44 f3 0f 10 41 20 e9 00 00 00 00"; BYTE origBytes[5] = {}; uintptr_t InstructionAddress = 0;}
-namespace LocalPlayer { struct Vec3 { float x, y, z; }; std::atomic<Vec3> g_cachedCoords{ {0,0,0} }; bool Enabled = false; bool flyEnabled = false; bool FlyHotkeyWasDown = false; inline bool KillKeyEnabled = false; inline bool KillKeyWasDown = false; uintptr_t destinyBase = 0x301F8F0; std::atomic<uintptr_t> realPlayer = 0; bool mem_allocated = false; uintptr_t memAllocatedAddress = 0; uintptr_t addrMemAllocatedAddress = 0; std::string AOB = "0F 10 89 ? ? ? ? 0F 54 0D ? ? ? ? 66 0F 6F ? ? ? ? ? 0F 54 C8 66 0F 72 D2 ? 66 0F 72 F2 ? 0F 55 C2 0F 56 C8 0F 11 0A E9 ? ? ? ? 48 81 C1"; std::string shellcode_hex = "50 48 89 C8 48 A3 FF FF FF FF FF FF FF FF 58 0F 10 89 C0 01 00 00 E9 00 00 00 00"; BYTE origBytes[7] = {}; uintptr_t InstructionAddress = 0; uintptr_t disableGravAddress = 0; std::string disableGravAOB = "88 51 79 8B D0"; std::string disableGravShellcode_hex = "C7 41 79 01 00 00 00 8B D0 E9 00 00 00 00"; BYTE disableGravOrigBytes[5] = {}; uintptr_t disableGravMemAllocatedAddress = 0; bool disableGrav_mem_allocated = false; }
-namespace ViewAngles { struct Vec2 { float pitch, yaw; }; std::atomic<uintptr_t> g_viewBase{0}; std::atomic<ViewAngles::Vec2> g_cachedAngles{{0.0f,0.0f}}; std::atomic<bool> g_cacheThreadRunning{false}; bool Enabled = false; bool mem_allocated = false; uintptr_t memAllocatedAddress = 0; uintptr_t addrMemAllocatedAddress = 0; std::string AOB = "F3 0F 11 47 1C 7A"; std::string shellcode_hex = "50 48 89 F8 48 A3 FF FF FF FF FF FF FF FF 58 F3 0F 11 47 1C E9 00 00 00 00"; BYTE origBytes[5] = {}; uintptr_t InstructionAddress = 0; inline void CacheLoop(DWORD pid) { g_cacheThreadRunning = true; uintptr_t temp_addr_storage = 0; while (g_cacheThreadRunning) { if (addrMemAllocatedAddress == 0) { std::this_thread::sleep_for(std::chrono::milliseconds(100)); continue; } temp_addr_storage = DriverComm::read_memory<uintptr_t>(addrMemAllocatedAddress); g_viewBase.store(temp_addr_storage); if (temp_addr_storage != 0) { Vec2 angles_val = DriverComm::read_memory<Vec2>(temp_addr_storage + 0x18); g_cachedAngles.store(angles_val); } if (LocalPlayer::realPlayer.load() != 0) { LocalPlayer::Vec3 coords_val = DriverComm::read_memory<LocalPlayer::Vec3>(LocalPlayer::realPlayer.load() + 0x1C0); LocalPlayer::g_cachedCoords.store(coords_val); } std::this_thread::sleep_for(std::chrono::milliseconds(150)); } } }
-namespace Ghostmode { bool Enabled = false; bool mem_allocated = false; uintptr_t memAllocatedAddress = 0; std::string AOB = "F3 0F 11 4C 24 38 B9 DD AD 93 43 8B 5C 24 38 B8 9C 6E 3F 2B 66 66 0F 1F 84 00 00 00 00 00"; BYTE origBytes[6] = {}; std::string shellcode_hex = "b8 00 00 80 bf 66 0f 6e c8 f3 0f 11 4c 24 38 e9 00 00 00 00"; uintptr_t InstructionAddress = 0;}
-namespace Godmode { bool Enabled = false; bool mem_allocated = false; uintptr_t memAllocatedAddress = 0; std::string AOB = "33 DA C1 C3 10 E8 ? ? ? ? 48"; std::string shellcode_hex = "6b db 01 e9 00 00 00 00"; BYTE origBytes[5] = {}; uintptr_t InstructionAddress = 0;}
-namespace InfAmmo { bool Enabled = false; bool mem_allocated = false; uintptr_t memAllocatedAddress = 0; std::string AOB = "44 0F 28 BD F0 05 00 00 48 83 C3"; std::string shellcode_hex = "81 bd f0 05 00 00 00 00 80 bf 0f 85 00 00 00 00 c7 85 f0 05 00 00 00 00 00 00 44 0f 28 bd f0 05 00 00 e9 00 00 00 00"; BYTE origBytes[8] = {}; uintptr_t InstructionAddress = 0;}
-namespace dmgMult { bool Enabled = false; bool mem_allocated = false; uintptr_t memAllocatedAddress = 0; std::string AOB = "F3 44 0F 10 61 24 44 0F 29 68 88 F3 44 0F 10 69 1C"; std::string shellcode_hex = "c7 41 24 00 40 9c 45 f3 44 0f 10 61 24 e9 00 00 00 00"; BYTE origBytes[6] = {}; uintptr_t InstructionAddress = 0;}
-namespace FOV { std::string AOB = "30 00 00 00 00 00 00 00 28 C8 0A 00 00 00 00 00 40 01 00 00 00 00 00 00 A0 08"; uint8_t fov = 0; uintptr_t ptr = 0; uintptr_t offset = 0x530; uintptr_t pointer = 0x5DC;}
-namespace RPM { bool Enabled = false; bool mem_allocated = false; uintptr_t memAllocatedAddress = 0; std::string AOB = "F3 0F 11 86 CC 17 00 00 48"; std::string shellcode_hex = "f3 0f 10 86 9c 17 00 00 f3 0f 59 c0 f3 0f 11 86 9c 17 00 00 f3 0f 11 86 cc 17 00 00 e9 00 00 00 00"; BYTE origBytes[8] = {}; uintptr_t InstructionAddress = 0;}
-namespace NoRecoil { bool Enabled = false; bool mem_allocated = false; uintptr_t memAllocatedAddress = 0; std::string AOB = "0F 11 8B ? ? ? ? 0F 28 CD";  std::string shellcode_hex = "66 0f ef c9 0f 11 8b 50 10 00 00 e9 00 00 00 00"; BYTE origBytes[7] = {}; uintptr_t InstructionAddress = 0;}
-namespace OHK { bool Enabled = false; bool mem_allocated = false; uintptr_t memAllocatedAddress = 0; std::string AOB = "F3 0F 11 44 24 50 33 C0 8B";  std::string shellcode_hex = "0f ef c0 f3 0f 11 44 24 32 e9 00 00 00 00"; BYTE origBytes[6] = {}; uintptr_t InstructionAddress = 0;}
-namespace NoJoinAllies { bool Enabled = false; std::string AOB = "48 01 47 ? EB ? 48"; BYTE nops[6] = { 0x90, 0x90, 0x90, 0x90, 0x90, 0x90 }; BYTE origBytes[6] = {}; uintptr_t InstructionAddress = 0;}
-namespace NoTurnBack { bool Enabled = false; std::string AOB = "F3 0F 11 46 ? E9 ? ? ? ? 44 0F B6"; BYTE nops[] = { 0x90, 0x90, 0x90, 0x90, 0x90 }; BYTE origBytes[5] = {}; uintptr_t InstructionAddress = 0;}
-namespace InfSwordAmmo {  bool Enabled = false; std::string AOB = "0F 28 C7 F3 41 0F 5C C0 0F 2F C6 ? ? 41 0F 28 F8 F3"; BYTE nops[] = { 0x90, 0x90, 0x90, 0x90, 0x90, 0x90, 0x90, 0x90 }; BYTE origBytes[8] = {}; uintptr_t InstructionAddress = 0;}
-namespace SparrowAnywhere {  bool Enabled = false; std::string AOB = "74 ?? 48 8B C8 48 89 7C 24 30 E8 ?? ?? ?? ?? 48 8B CB 48 8B F8 E8 ?? ?? ?? ?? 48 8B D8 48 85 C0 ?? ?? 80 78 0E 00"; BYTE mybyte[] = { 0x75 }; BYTE origByte[] = { 0x74 }; uintptr_t InstructionAddress = 0;}
-namespace InfStacks {bool Enabled = false; bool mem_allocated = false; uintptr_t memAllocatedAddress = 0; std::string AOB = "89 5F ? 74 ? 8B"; std::string shellcode_hex = "bb 64 00 00 00 89 5f 30 e9 00 00 00 00"; BYTE origBytes[5] = {}; uintptr_t InstructionAddress = 0;}
-namespace NoRezTokens {  bool Enabled = false; std::string AOB = "75 08 E8 ?? ?? ?? ?? 89"; BYTE myByte[] = { 0xEB }; BYTE origByte[] = { 0x75 }; uintptr_t InstructionAddress = 0;}
-namespace InstaRespawn {  bool Enabled = false; std::string AOB = "49 8B ? ? ? ? ? 48 8B 08 48 3B"; BYTE myBytes[] = { 0x48, 0x31, 0xD2, 0x90, 0x90, 0x90, 0x90 }; BYTE origBytes[7] = {}; uintptr_t InstructionAddress = 0;}
-namespace RespawnAnywhere { bool Enabled = false; bool mem_allocated = false; uintptr_t memAllocatedAddress = 0; std::string AOB = "48 89 ? ? ? ? ? ? ? 0F 28 CE 48 8D"; std::string shellcode_hex = "50 48 31 c0 48 89 86 68 08 00 00 58 e9 00 00 00 00"; BYTE origBytes[7] = {}; uintptr_t InstructionAddress = 0;}
-namespace ShootThru {  bool Enabled = false; std::string AOB = "0F 11 02 0F 11 4A 10 44 0F 28 0D"; BYTE nops[] = { 0x90, 0x90, 0x90 }; BYTE origBytes[3] = {}; uintptr_t InstructionAddress = 0;}
-namespace Chams { bool Enabled = false; bool mem_allocated = false; uintptr_t memAllocatedAddress = 0; std::string AOB = "0F 10 02 48 83 C1 60"; std::string shellcode_hex = "b8 a6 95 80 80 39 42 78 0f 85 06 00 00 00 c7 02 00 00 20 41 0f 10 02 48 83 c1 60 e9 00 00 00 00"; BYTE origBytes[7] = {}; uintptr_t InstructionAddress = 0;}
-namespace ImmuneBosses { std::atomic<bool> Enabled = false; std::atomic<bool> ThreadRunning = false; uintptr_t Address = 0; }
-namespace AbilityCharge { bool Enabled = false; bool WasKeyDown = false;  std::string AOB = "0F 10 02 48 83 C1 60"; std::string shellcode_hex = "50 b8 00 00 80 3f f3 0f 2a c0 48 83 c1 60 58 e9 00 00 00 00"; BYTE origBytes[7] = {}; uintptr_t InstructionAddress = 0;}
-namespace ImmuneAura {  bool Enabled = false; bool mem_allocated = false; uintptr_t memAllocatedAddress = 0; std::string AOB = "0F 10 02 48 83 C1 60"; std::string shellcode_hex = "50 b8 e8 03 00 00 f3 0f 2a c0 48 83 c1 60 58 e9 00 00 00 00"; BYTE origBytes[7] = {}; uintptr_t InstructionAddress = 0;}
-namespace IcarusDash {  bool Enabled = false; std::string AOB = "89 46 34 89 6E 3C"; BYTE nops[] = { 0x90, 0x90, 0x90 }; BYTE origBytes[3] = {}; uintptr_t InstructionAddress = 0;}
-namespace InstantInteract { bool Enabled = false; bool mem_allocated = false; uintptr_t memAllocatedAddress = 0; std::string AOB = "F3 0F 11 43 08 48 83 C4 30 5B C3 48"; std::string shellcode_hex = "c7 43 08 00 00 00 00 e9 00 00 00 00"; BYTE origBytes[5] = {}; uintptr_t InstructionAddress = 0;}
-namespace InteractThruWalls { bool Enabled = false; bool mem_allocated1 = false; bool mem_allocated2 = false; uintptr_t memAllocatedAddress1 = 0; uintptr_t memAllocatedAddress2 = 0; std::string AOB1 = "8B 54 01 6C 8B 4F 24"; std::string AOB2 = "0F 11 02 0F 11 4A 10 44 0F 28 0D"; std::string shellcode1_hex = "c7 44 01 6c 00 00 7a 44 8b 54 01 6c 8b 4f 24 e9 00 00 00 00"; std::string shellcode2_hex = "c7 02 10 27 00 00 0f 11 4a 10 e9 00 00 00 00"; BYTE origBytes1[7] = {}; BYTE origBytes2[7] = {}; uintptr_t InstructionAddress1 = 0; uintptr_t InstructionAddress2 = 0;}
-namespace GameSpeed {  bool Enabled = false; std::string AOB = "00 5B 24 49 00 24 74 49 0A D7 23 3C 0A D7 23 3C 0A D7 23 3C 0A D7 23 3C 00 00 00 00 00 00 00 00 00 00 00"; uintptr_t Address = 0; float FastValue = 9000.0f; float NormalValue = 673200.0f; bool WasKeyDown = false;}
-namespace LobbyCrasher {  bool Enabled = false; std::string AOB = "C7 43 04 FF FF FF FF C6 03 01 48 83 C4 20 5B C3 48 8B"; BYTE nops[] = { 0x90, 0x90, 0x90, 0x90, 0x90, 0x90, 0x90 }; BYTE origBytes[7] = {}; uintptr_t InstructionAddress = 0;}
-namespace GSize {  bool Enabled = false;  std::string AOB = "00 00 80 3F 80 F0 FA 02"; float Value = 0.0f; float inputVal = 0; uintptr_t Address = 0; }
-namespace Oxygen {  bool Enabled = false; std::string AOB = "0F 28 C8 E8 ? ? ? ? 0F B6 43 0C"; BYTE nops[] = { 0x90 ,0x90, 0x90 }; BYTE origBytes[3] = {}; uintptr_t InstructionAddress = 0;}
-namespace InfSparrowBoost {  bool Enabled = false; std::string AOB = "72 34 48 8D 4B 50"; BYTE myByte[] = { 0x77 }; BYTE origByte[] = { 0x72 }; uintptr_t InstructionAddress = 0;}
-namespace InfBuffTimers {  bool Enabled = false; std::string AOB = "48 89 8B A0 00 00 00 48 8D 4C 24 30 E8 ? ? ? ? 48 8B 08 48 39"; BYTE nops[] = { 0x90, 0x90, 0x90, 0x90, 0x90, 0x90, 0x90 }; BYTE origBytes[7] = {}; uintptr_t InstructionAddress = 0;}
-namespace InfExoticBuffTimers {  bool Enabled = false; std::string AOB = "F3 0F 5C C7 F3 0F 5F C6 0F 2E"; BYTE nops[] = {0x90, 0x90, 0x90, 0x90, 0x90, 0x90, 0x90, 0x90}; BYTE origBytes[8] = {}; uintptr_t InstructionAddress = 0;}
-namespace AntiFlinch {  bool Enabled = false;  std::string AOB1 = "F3 0F 11 8B E0 16 00 00"; std::string AOB2 = "F3 0F 11 8B E4 16 00 00"; std::string AOB3 = "F3 0F 11 83 E8 16 00 00"; BYTE nops[] = { 0x90, 0x90, 0x90, 0x90, 0x90, 0x90, 0x90, 0x90 }; BYTE origBytes1[8] = {}; BYTE origBytes2[8] = {}; BYTE origBytes3[8] = {}; uintptr_t InstructionAddress1 = 0; uintptr_t InstructionAddress2 = 0; uintptr_t InstructionAddress3 = 0;}
+namespace Killaura { bool Enabled = false; bool mem_allocated = false; std::atomic<uintptr_t> memAllocatedAddress{0}; std::string AOB = "F3 0F 10 41 20 32 C0 0F C6 C0 ? 0F 11 02 C3 ? 0F ? ? ? 32"; std::string shellcode_hex = "c7 41 20 00 00 7a 44 f3 0f 10 41 20 e9 00 00 00 00"; BYTE origBytes[5] = {}; std::atomic<uintptr_t> InstructionAddress{0};}
+namespace LocalPlayer { struct Vec3 { float x, y, z; }; std::atomic<Vec3> g_cachedCoords{ {0,0,0} }; bool Enabled = false; bool flyEnabled = false; bool FlyHotkeyWasDown = false; inline bool KillKeyEnabled = false; inline bool KillKeyWasDown = false; uintptr_t destinyBase = 0x301F8F0; std::atomic<uintptr_t> realPlayer = 0; bool mem_allocated = false; std::atomic<uintptr_t> memAllocatedAddress{0}; std::atomic<uintptr_t> addrMemAllocatedAddress{0}; std::string AOB = "0F 10 89 ? ? ? ? 0F 54 0D ? ? ? ? 66 0F 6F ? ? ? ? ? 0F 54 C8 66 0F 72 D2 ? 66 0F 72 F2 ? 0F 55 C2 0F 56 C8 0F 11 0A E9 ? ? ? ? 48 81 C1"; std::string shellcode_hex = "50 48 89 C8 48 A3 FF FF FF FF FF FF FF FF 58 0F 10 89 C0 01 00 00 E9 00 00 00 00"; BYTE origBytes[7] = {}; std::atomic<uintptr_t> InstructionAddress{0}; std::atomic<uintptr_t> disableGravAddress{0}; std::string disableGravAOB = "88 51 79 8B D0"; std::string disableGravShellcode_hex = "C7 41 79 01 00 00 00 8B D0 E9 00 00 00 00"; BYTE disableGravOrigBytes[5] = {}; std::atomic<uintptr_t> disableGravMemAllocatedAddress{0}; bool disableGrav_mem_allocated = false; }
+namespace ViewAngles { struct Vec2 { float pitch, yaw; }; std::atomic<uintptr_t> g_viewBase{0}; std::atomic<ViewAngles::Vec2> g_cachedAngles{{0.0f,0.0f}}; std::atomic<bool> g_cacheThreadRunning{false}; bool Enabled = false; bool mem_allocated = false; std::atomic<uintptr_t> memAllocatedAddress{0}; std::atomic<uintptr_t> addrMemAllocatedAddress{0}; std::string AOB = "F3 0F 11 47 1C 7A"; std::string shellcode_hex = "50 48 89 F8 48 A3 FF FF FF FF FF FF FF FF 58 F3 0F 11 47 1C E9 00 00 00 00"; BYTE origBytes[5] = {}; std::atomic<uintptr_t> InstructionAddress{0}; inline void CacheLoop(DWORD pid) { g_cacheThreadRunning = true; uintptr_t temp_addr_storage_val = 0; Vec2 angles_val_cache; LocalPlayer::Vec3 coords_val_cache; while (g_cacheThreadRunning.load()) { if (addrMemAllocatedAddress.load() == 0) { std::this_thread::sleep_for(std::chrono::milliseconds(100)); continue; }  NTSTATUS status = DriverComm::read_memory<uintptr_t>(addrMemAllocatedAddress.load(), temp_addr_storage_val); if (NT_SUCCESS(status)) { g_viewBase.store(temp_addr_storage_val); if (temp_addr_storage_val != 0) {  NTSTATUS angle_status = DriverComm::read_memory<Vec2>(temp_addr_storage_val + 0x18, angles_val_cache); if(NT_SUCCESS(angle_status)) g_cachedAngles.store(angles_val_cache); } } if (LocalPlayer::realPlayer.load() != 0) {  NTSTATUS coord_status = DriverComm::read_memory<LocalPlayer::Vec3>(LocalPlayer::realPlayer.load() + 0x1C0, coords_val_cache); if(NT_SUCCESS(coord_status)) LocalPlayer::g_cachedCoords.store(coords_val_cache); } std::this_thread::sleep_for(std::chrono::milliseconds(150)); } } }
+namespace Ghostmode { bool Enabled = false; bool mem_allocated = false; std::atomic<uintptr_t> memAllocatedAddress{0}; std::string AOB = "F3 0F 11 4C 24 38 B9 DD AD 93 43 8B 5C 24 38 B8 9C 6E 3F 2B 66 66 0F 1F 84 00 00 00 00 00"; BYTE origBytes[6] = {}; std::string shellcode_hex = "b8 00 00 80 bf 66 0f 6e c8 f3 0f 11 4c 24 38 e9 00 00 00 00"; std::atomic<uintptr_t> InstructionAddress{0};}
+namespace Godmode { bool Enabled = false; bool mem_allocated = false; std::atomic<uintptr_t> memAllocatedAddress{0}; std::string AOB = "33 DA C1 C3 10 E8 ? ? ? ? 48"; std::string shellcode_hex = "6b db 01 e9 00 00 00 00"; BYTE origBytes[5] = {}; std::atomic<uintptr_t> InstructionAddress{0};}
+namespace InfAmmo { bool Enabled = false; bool mem_allocated = false; std::atomic<uintptr_t> memAllocatedAddress{0}; std::string AOB = "44 0F 28 BD F0 05 00 00 48 83 C3"; std::string shellcode_hex = "81 bd f0 05 00 00 00 00 80 bf 0f 85 00 00 00 00 c7 85 f0 05 00 00 00 00 00 00 44 0f 28 bd f0 05 00 00 e9 00 00 00 00"; BYTE origBytes[8] = {}; std::atomic<uintptr_t> InstructionAddress{0};}
+namespace dmgMult { bool Enabled = false; bool mem_allocated = false; std::atomic<uintptr_t> memAllocatedAddress{0}; std::string AOB = "F3 44 0F 10 61 24 44 0F 29 68 88 F3 44 0F 10 69 1C"; std::string shellcode_hex = "c7 41 24 00 40 9c 45 f3 44 0f 10 61 24 e9 00 00 00 00"; BYTE origBytes[6] = {}; std::atomic<uintptr_t> InstructionAddress{0};}
+namespace FOV { std::string AOB = "30 00 00 00 00 00 00 00 28 C8 0A 00 00 00 00 00 40 01 00 00 00 00 00 00 A0 08"; uint8_t fov = 0; std::atomic<uintptr_t> ptr{0}; uintptr_t offset = 0x530; uintptr_t pointer = 0x5DC;}
+namespace RPM { bool Enabled = false; bool mem_allocated = false; std::atomic<uintptr_t> memAllocatedAddress{0}; std::string AOB = "F3 0F 11 86 CC 17 00 00 48"; std::string shellcode_hex = "f3 0f 10 86 9c 17 00 00 f3 0f 59 c0 f3 0f 11 86 9c 17 00 00 f3 0f 11 86 cc 17 00 00 e9 00 00 00 00"; BYTE origBytes[8] = {}; std::atomic<uintptr_t> InstructionAddress{0};}
+namespace NoRecoil { bool Enabled = false; bool mem_allocated = false; std::atomic<uintptr_t> memAllocatedAddress{0}; std::string AOB = "0F 11 8B ? ? ? ? 0F 28 CD";  std::string shellcode_hex = "66 0f ef c9 0f 11 8b 50 10 00 00 e9 00 00 00 00"; BYTE origBytes[7] = {}; std::atomic<uintptr_t> InstructionAddress{0};}
+namespace OHK { bool Enabled = false; bool mem_allocated = false; std::atomic<uintptr_t> memAllocatedAddress{0}; std::string AOB = "F3 0F 11 44 24 50 33 C0 8B";  std::string shellcode_hex = "0f ef c0 f3 0f 11 44 24 32 e9 00 00 00 00"; BYTE origBytes[6] = {}; std::atomic<uintptr_t> InstructionAddress{0};}
+namespace NoJoinAllies { bool Enabled = false; std::string AOB = "48 01 47 ? EB ? 48"; BYTE nops[6] = { 0x90, 0x90, 0x90, 0x90, 0x90, 0x90 }; BYTE origBytes[6] = {}; std::atomic<uintptr_t> InstructionAddress{0};}
+namespace NoTurnBack { bool Enabled = false; std::string AOB = "F3 0F 11 46 ? E9 ? ? ? ? 44 0F B6"; BYTE nops[] = { 0x90, 0x90, 0x90, 0x90, 0x90 }; BYTE origBytes[5] = {}; std::atomic<uintptr_t> InstructionAddress{0};}
+namespace InfSwordAmmo {  bool Enabled = false; std::string AOB = "0F 28 C7 F3 41 0F 5C C0 0F 2F C6 ? ? 41 0F 28 F8 F3"; BYTE nops[] = { 0x90, 0x90, 0x90, 0x90, 0x90, 0x90, 0x90, 0x90 }; BYTE origBytes[8] = {}; std::atomic<uintptr_t> InstructionAddress{0};}
+namespace SparrowAnywhere {  bool Enabled = false; std::string AOB = "74 ?? 48 8B C8 48 89 7C 24 30 E8 ?? ?? ?? ?? 48 8B CB 48 8B F8 E8 ?? ?? ?? ?? 48 8B D8 48 85 C0 ?? ?? 80 78 0E 00"; BYTE mybyte[] = { 0x75 }; BYTE origByte[] = { 0x74 }; std::atomic<uintptr_t> InstructionAddress{0};}
+namespace InfStacks {bool Enabled = false; bool mem_allocated = false; std::atomic<uintptr_t> memAllocatedAddress{0}; std::string AOB = "89 5F ? 74 ? 8B"; std::string shellcode_hex = "bb 64 00 00 00 89 5f 30 e9 00 00 00 00"; BYTE origBytes[5] = {}; std::atomic<uintptr_t> InstructionAddress{0};}
+namespace NoRezTokens {  bool Enabled = false; std::string AOB = "75 08 E8 ?? ?? ?? ?? 89"; BYTE myByte[] = { 0xEB }; BYTE origByte[] = { 0x75 }; std::atomic<uintptr_t> InstructionAddress{0};}
+namespace InstaRespawn {  bool Enabled = false; std::string AOB = "49 8B ? ? ? ? ? 48 8B 08 48 3B"; BYTE myBytes[] = { 0x48, 0x31, 0xD2, 0x90, 0x90, 0x90, 0x90 }; BYTE origBytes[7] = {}; std::atomic<uintptr_t> InstructionAddress{0};}
+namespace RespawnAnywhere { bool Enabled = false; bool mem_allocated = false; std::atomic<uintptr_t> memAllocatedAddress{0}; std::string AOB = "48 89 ? ? ? ? ? ? ? 0F 28 CE 48 8D"; std::string shellcode_hex = "50 48 31 c0 48 89 86 68 08 00 00 58 e9 00 00 00 00"; BYTE origBytes[7] = {}; std::atomic<uintptr_t> InstructionAddress{0};}
+namespace ShootThru {  bool Enabled = false; std::string AOB = "0F 11 02 0F 11 4A 10 44 0F 28 0D"; BYTE nops[] = { 0x90, 0x90, 0x90 }; BYTE origBytes[3] = {}; std::atomic<uintptr_t> InstructionAddress{0};}
+namespace Chams { bool Enabled = false; bool mem_allocated = false; std::atomic<uintptr_t> memAllocatedAddress{0}; std::string AOB = "0F 10 02 48 83 C1 60"; std::string shellcode_hex = "b8 a6 95 80 80 39 42 78 0f 85 06 00 00 00 c7 02 00 00 20 41 0f 10 02 48 83 c1 60 e9 00 00 00 00"; BYTE origBytes[7] = {}; std::atomic<uintptr_t> InstructionAddress{0};}
+namespace ImmuneBosses { std::atomic<bool> Enabled = false; std::atomic<bool> ThreadRunning = false; std::atomic<uintptr_t> Address{0}; }
+namespace AbilityCharge { bool Enabled = false; bool WasKeyDown = false;  std::string AOB = "0F 10 02 48 83 C1 60"; std::string shellcode_hex = "50 b8 00 00 80 3f f3 0f 2a c0 48 83 c1 60 58 e9 00 00 00 00"; BYTE origBytes[7] = {}; std::atomic<uintptr_t> InstructionAddress{0};}
+namespace ImmuneAura {  bool Enabled = false; bool mem_allocated = false; std::atomic<uintptr_t> memAllocatedAddress{0}; std::string AOB = "0F 10 02 48 83 C1 60"; std::string shellcode_hex = "50 b8 e8 03 00 00 f3 0f 2a c0 48 83 c1 60 58 e9 00 00 00 00"; BYTE origBytes[7] = {}; std::atomic<uintptr_t> InstructionAddress{0};}
+namespace IcarusDash {  bool Enabled = false; std::string AOB = "89 46 34 89 6E 3C"; BYTE nops[] = { 0x90, 0x90, 0x90 }; BYTE origBytes[3] = {}; std::atomic<uintptr_t> InstructionAddress{0};}
+namespace InstantInteract { bool Enabled = false; bool mem_allocated = false; std::atomic<uintptr_t> memAllocatedAddress{0}; std::string AOB = "F3 0F 11 43 08 48 83 C4 30 5B C3 48"; std::string shellcode_hex = "c7 43 08 00 00 00 00 e9 00 00 00 00"; BYTE origBytes[5] = {}; std::atomic<uintptr_t> InstructionAddress{0};}
+namespace InteractThruWalls { bool Enabled = false; bool mem_allocated1 = false; bool mem_allocated2 = false; std::atomic<uintptr_t> memAllocatedAddress1{0}; std::atomic<uintptr_t> memAllocatedAddress2{0}; std::string AOB1 = "8B 54 01 6C 8B 4F 24"; std::string AOB2 = "0F 11 02 0F 11 4A 10 44 0F 28 0D"; std::string shellcode1_hex = "c7 44 01 6c 00 00 7a 44 8b 54 01 6c 8b 4f 24 e9 00 00 00 00"; std::string shellcode2_hex = "c7 02 10 27 00 00 0f 11 4a 10 e9 00 00 00 00"; BYTE origBytes1[7] = {}; BYTE origBytes2[7] = {}; std::atomic<uintptr_t> InstructionAddress1{0}; std::atomic<uintptr_t> InstructionAddress2{0};}
+namespace GameSpeed {  bool Enabled = false; std::string AOB = "00 5B 24 49 00 24 74 49 0A D7 23 3C 0A D7 23 3C 0A D7 23 3C 0A D7 23 3C 00 00 00 00 00 00 00 00 00 00 00"; std::atomic<uintptr_t> Address{0}; float FastValue = 9000.0f; float NormalValue = 673200.0f; bool WasKeyDown = false;}
+namespace LobbyCrasher {  bool Enabled = false; std::string AOB = "C7 43 04 FF FF FF FF C6 03 01 48 83 C4 20 5B C3 48 8B"; BYTE nops[] = { 0x90, 0x90, 0x90, 0x90, 0x90, 0x90, 0x90 }; BYTE origBytes[7] = {}; std::atomic<uintptr_t> InstructionAddress{0};}
+namespace GSize {  bool Enabled = false;  std::string AOB = "00 00 80 3F 80 F0 FA 02"; float Value = 0.0f; float inputVal = 0; std::atomic<uintptr_t> Address{0}; }
+namespace Oxygen {  bool Enabled = false; std::string AOB = "0F 28 C8 E8 ? ? ? ? 0F B6 43 0C"; BYTE nops[] = { 0x90 ,0x90, 0x90 }; BYTE origBytes[3] = {}; std::atomic<uintptr_t> InstructionAddress{0};}
+namespace InfSparrowBoost {  bool Enabled = false; std::string AOB = "72 34 48 8D 4B 50"; BYTE myByte[] = { 0x77 }; BYTE origByte[] = { 0x72 }; std::atomic<uintptr_t> InstructionAddress{0};}
+namespace InfBuffTimers {  bool Enabled = false; std::string AOB = "48 89 8B A0 00 00 00 48 8D 4C 24 30 E8 ? ? ? ? 48 8B 08 48 39"; BYTE nops[] = { 0x90, 0x90, 0x90, 0x90, 0x90, 0x90, 0x90 }; BYTE origBytes[7] = {}; std::atomic<uintptr_t> InstructionAddress{0};}
+namespace InfExoticBuffTimers {  bool Enabled = false; std::string AOB = "F3 0F 5C C7 F3 0F 5F C6 0F 2E"; BYTE nops[] = {0x90, 0x90, 0x90, 0x90, 0x90, 0x90, 0x90, 0x90}; BYTE origBytes[8] = {}; std::atomic<uintptr_t> InstructionAddress{0};}
+namespace AntiFlinch {  bool Enabled = false;  std::string AOB1 = "F3 0F 11 8B E0 16 00 00"; std::string AOB2 = "F3 0F 11 8B E4 16 00 00"; std::string AOB3 = "F3 0F 11 83 E8 16 00 00"; BYTE nops[] = { 0x90, 0x90, 0x90, 0x90, 0x90, 0x90, 0x90, 0x90 }; BYTE origBytes1[8] = {}; BYTE origBytes2[8] = {}; BYTE origBytes3[8] = {}; std::atomic<uintptr_t> InstructionAddress1{0}; std::atomic<uintptr_t> InstructionAddress2{0}; std::atomic<uintptr_t> InstructionAddress3{0};}
 // ActivityLoader: New shellcode intends to mov RDX into the address pointed to by addrMemAllocatedAddress, then executes original instruction.
 // mov rax, <addrMemAllocatedAddress_value> ; mov [rax], rdx ; movzx r9d, word ptr [rdx+2] (original instruction)
-namespace ActivityLoader { bool Enabled = false; bool mem_allocated = false; uintptr_t memAllocatedAddress = 0; uintptr_t addrMemAllocatedAddress = 0;  std::string AOB = "44 0F B7 4A 02 44"; std::string shellcode_hex = "48 B8 00 00 00 00 00 00 00 00 48 89 10 44 0F B7 4A 02"; BYTE origBytes[5] = {}; uintptr_t InstructionAddress = 0;}
-namespace Mag999 { bool Enabled = false;  bool mem_allocated = false; uintptr_t memAllocatedAddress = 0;  std::string AOB = "0F 10 04 C1 48 83 C2 10 49"; std::string shellcode_hex = "50 B8 8A 49 FD 79 66 0F 6E D0 58 F3 0F 10 44 C1 B8 0F 2E C2 0F 85 16 00 00 00 50 B8 20 BC BE 4C 66 0F 6E D0 58 F3 0F 11 14 C1 F3 0F 11 54 C1 50 50 B8 02 03 02 34 66 0F 6E D0 58 F3 0F 10 44 C1 B8 0F 2E C2 0F 85 16 00 00 00 50 B8 20 BC BE 4C 66 0F 6E D0 58 F3 0F 11 14 C1 F3 0F 11 54 C1 10 0F 10 04 C1 48 83 C2 10 E9 00 00 00 00"; BYTE origBytes[8] = {}; uintptr_t InstructionAddress = 0;}
+namespace ActivityLoader { bool Enabled = false; bool mem_allocated = false; std::atomic<uintptr_t> memAllocatedAddress{0}; std::atomic<uintptr_t> addrMemAllocatedAddress{0};  std::string AOB = "44 0F B7 4A 02 44"; std::string shellcode_hex = "48 B8 00 00 00 00 00 00 00 00 48 89 10 44 0F B7 4A 02"; BYTE origBytes[5] = {}; std::atomic<uintptr_t> InstructionAddress{0};}
+namespace Mag999 { bool Enabled = false;  bool mem_allocated = false; std::atomic<uintptr_t> memAllocatedAddress{0};  std::string AOB = "0F 10 04 C1 48 83 C2 10 49"; std::string shellcode_hex = "50 B8 8A 49 FD 79 66 0F 6E D0 58 F3 0F 10 44 C1 B8 0F 2E C2 0F 85 16 00 00 00 50 B8 20 BC BE 4C 66 0F 6E D0 58 F3 0F 11 14 C1 F3 0F 11 54 C1 50 50 B8 02 03 02 34 66 0F 6E D0 58 F3 0F 10 44 C1 B8 0F 2E C2 0F 85 16 00 00 00 50 B8 20 BC BE 4C 66 0F 6E D0 58 F3 0F 11 14 C1 F3 0F 11 54 C1 10 0F 10 04 C1 48 83 C2 10 E9 00 00 00 00"; BYTE origBytes[8] = {}; std::atomic<uintptr_t> InstructionAddress{0};}
 
 
 const SIZE_T DEFAULT_SCAN_REGION_SIZE = 0x7FFFFFF;
-inline void PerformStartupAobScans(uintptr_t moduleBaseAddress) { if (moduleBaseAddress == 0) { LogMessage("[-] PerformStartupAobScans: Invalid moduleBaseAddress (0)."); return; } auto ScanAndLog = [&](const char* featureName, const std::string& aobPattern, uintptr_t& instructionAddress) { instructionAddress = DriverComm::AOBScan(moduleBaseAddress, DEFAULT_SCAN_REGION_SIZE, aobPattern.c_str(), "");}; ScanAndLog("Killaura", Killaura::AOB, Killaura::InstructionAddress); ScanAndLog("LocalPlayer", LocalPlayer::AOB, LocalPlayer::InstructionAddress); ScanAndLog("LocalPlayer Disable Gravity", LocalPlayer::disableGravAOB, LocalPlayer::disableGravAddress); ScanAndLog("ViewAngles", ViewAngles::AOB, ViewAngles::InstructionAddress); ScanAndLog("Ghostmode", Ghostmode::AOB, Ghostmode::InstructionAddress); ScanAndLog("Godmode", Godmode::AOB, Godmode::InstructionAddress); ScanAndLog("InfAmmo", InfAmmo::AOB, InfAmmo::InstructionAddress); ScanAndLog("dmgMult", dmgMult::AOB, dmgMult::InstructionAddress); ScanAndLog("RPM", RPM::AOB, RPM::InstructionAddress); ScanAndLog("NoRecoil", NoRecoil::AOB, NoRecoil::InstructionAddress); ScanAndLog("OHK", OHK::AOB, OHK::InstructionAddress); ScanAndLog("NoJoinAllies", NoJoinAllies::AOB, NoJoinAllies::InstructionAddress); ScanAndLog("NoTurnBack", NoTurnBack::AOB, NoTurnBack::InstructionAddress); ScanAndLog("InfSwordAmmo", InfSwordAmmo::AOB, InfSwordAmmo::InstructionAddress); ScanAndLog("SparrowAnywhere", SparrowAnywhere::AOB, SparrowAnywhere::InstructionAddress); ScanAndLog("InfStacks", InfStacks::AOB, InfStacks::InstructionAddress); ScanAndLog("NoRezTokens", NoRezTokens::AOB, NoRezTokens::InstructionAddress); ScanAndLog("InstaRespawn", InstaRespawn::AOB, InstaRespawn::InstructionAddress); ScanAndLog("RespawnAnywhere", RespawnAnywhere::AOB, RespawnAnywhere::InstructionAddress); ScanAndLog("ShootThru", ShootThru::AOB, ShootThru::InstructionAddress); ScanAndLog("Chams", Chams::AOB, Chams::InstructionAddress); ScanAndLog("AbilityCharge", AbilityCharge::AOB, AbilityCharge::InstructionAddress); ScanAndLog("ImmuneAura", ImmuneAura::AOB, ImmuneAura::InstructionAddress); ScanAndLog("IcarusDash", IcarusDash::AOB, IcarusDash::InstructionAddress); ScanAndLog("InstantInteract", InstantInteract::AOB, InstantInteract::InstructionAddress); ScanAndLog("InteractThruWalls1", InteractThruWalls::AOB1, InteractThruWalls::InstructionAddress1); ScanAndLog("InteractThruWalls2", InteractThruWalls::AOB2, InteractThruWalls::InstructionAddress2); ScanAndLog("GameSpeed", GameSpeed::AOB, GameSpeed::Address); ScanAndLog("LobbyCrasher", LobbyCrasher::AOB, LobbyCrasher::InstructionAddress); ScanAndLog("GSize", GSize::AOB, GSize::Address); ScanAndLog("Oxygen", Oxygen::AOB, Oxygen::InstructionAddress); ScanAndLog("InfSparrowBoost", InfSparrowBoost::AOB, InfSparrowBoost::InstructionAddress); ScanAndLog("InfBuffTimers", InfBuffTimers::AOB, InfBuffTimers::InstructionAddress); ScanAndLog("InfExoticBuffTimers", InfExoticBuffTimers::AOB, InfExoticBuffTimers::InstructionAddress); ScanAndLog("AntiFlinch1", AntiFlinch::AOB1, AntiFlinch::InstructionAddress1); ScanAndLog("AntiFlinch2", AntiFlinch::AOB2, AntiFlinch::InstructionAddress2); ScanAndLog("AntiFlinch3", AntiFlinch::AOB3, AntiFlinch::InstructionAddress3); ScanAndLog("ActivityLoader", ActivityLoader::AOB, ActivityLoader::InstructionAddress); ScanAndLog("Mag999", Mag999::AOB, Mag999::InstructionAddress); ScanAndLog("FOV", FOV::AOB, FOV::ptr); }
-template<size_t N> inline bool ReadOriginalBytes(uintptr_t address, BYTE(&origBytes_array)[N]) { if (address == 0) return false; return DriverComm::read_memory_buffer(address, origBytes_array, N); }
-inline void PerformStartupByteReads() { if (Killaura::InstructionAddress) ReadOriginalBytes(Killaura::InstructionAddress, Killaura::origBytes); if (LocalPlayer::InstructionAddress) ReadOriginalBytes(LocalPlayer::InstructionAddress, LocalPlayer::origBytes); if (LocalPlayer::disableGravAddress) ReadOriginalBytes(LocalPlayer::disableGravAddress, LocalPlayer::disableGravOrigBytes); if (ViewAngles::InstructionAddress) ReadOriginalBytes(ViewAngles::InstructionAddress, ViewAngles::origBytes); if (Ghostmode::InstructionAddress) ReadOriginalBytes(Ghostmode::InstructionAddress, Ghostmode::origBytes); if (Godmode::InstructionAddress) ReadOriginalBytes(Godmode::InstructionAddress, Godmode::origBytes); if (InfAmmo::InstructionAddress) ReadOriginalBytes(InfAmmo::InstructionAddress, InfAmmo::origBytes); if (dmgMult::InstructionAddress) ReadOriginalBytes(dmgMult::InstructionAddress, dmgMult::origBytes); if (RPM::InstructionAddress) ReadOriginalBytes(RPM::InstructionAddress, RPM::origBytes); if (NoRecoil::InstructionAddress) ReadOriginalBytes(NoRecoil::InstructionAddress, NoRecoil::origBytes); if (OHK::InstructionAddress) ReadOriginalBytes(OHK::InstructionAddress, OHK::origBytes); if (NoJoinAllies::InstructionAddress) ReadOriginalBytes(NoJoinAllies::InstructionAddress, NoJoinAllies::origBytes); if (NoTurnBack::InstructionAddress) ReadOriginalBytes(NoTurnBack::InstructionAddress, NoTurnBack::origBytes); if (InfSwordAmmo::InstructionAddress) ReadOriginalBytes(InfSwordAmmo::InstructionAddress, InfSwordAmmo::origBytes); if (SparrowAnywhere::InstructionAddress) ReadOriginalBytes(SparrowAnywhere::InstructionAddress, SparrowAnywhere::origByte); if (InfStacks::InstructionAddress) ReadOriginalBytes(InfStacks::InstructionAddress, InfStacks::origBytes); if (NoRezTokens::InstructionAddress) ReadOriginalBytes(NoRezTokens::InstructionAddress, NoRezTokens::origByte); if (InstaRespawn::InstructionAddress) ReadOriginalBytes(InstaRespawn::InstructionAddress, InstaRespawn::origBytes); if (RespawnAnywhere::InstructionAddress) ReadOriginalBytes(RespawnAnywhere::InstructionAddress, RespawnAnywhere::origBytes); if (ShootThru::InstructionAddress) ReadOriginalBytes(ShootThru::InstructionAddress, ShootThru::origBytes); if (Chams::InstructionAddress) ReadOriginalBytes(Chams::InstructionAddress, Chams::origBytes); if (AbilityCharge::InstructionAddress) ReadOriginalBytes(AbilityCharge::InstructionAddress, AbilityCharge::origBytes); if (ImmuneAura::InstructionAddress) ReadOriginalBytes(ImmuneAura::InstructionAddress, ImmuneAura::origBytes); if (IcarusDash::InstructionAddress) ReadOriginalBytes(IcarusDash::InstructionAddress, IcarusDash::origBytes); if (InstantInteract::InstructionAddress) ReadOriginalBytes(InstantInteract::InstructionAddress, InstantInteract::origBytes); if (InteractThruWalls::InstructionAddress1) ReadOriginalBytes(InteractThruWalls::InstructionAddress1, InteractThruWalls::origBytes1); if (InteractThruWalls::InstructionAddress2) ReadOriginalBytes(InteractThruWalls::InstructionAddress2, InteractThruWalls::origBytes2); if (LobbyCrasher::InstructionAddress) ReadOriginalBytes(LobbyCrasher::InstructionAddress, LobbyCrasher::origBytes); if (Oxygen::InstructionAddress) ReadOriginalBytes(Oxygen::InstructionAddress, Oxygen::origBytes); if (InfSparrowBoost::InstructionAddress) ReadOriginalBytes(InfSparrowBoost::InstructionAddress, InfSparrowBoost::origByte); if (InfBuffTimers::InstructionAddress) ReadOriginalBytes(InfBuffTimers::InstructionAddress, InfBuffTimers::origBytes); if (InfExoticBuffTimers::InstructionAddress) ReadOriginalBytes(InfExoticBuffTimers::InstructionAddress, InfExoticBuffTimers::origBytes); if (AntiFlinch::InstructionAddress1) ReadOriginalBytes(AntiFlinch::InstructionAddress1, AntiFlinch::origBytes1); if (AntiFlinch::InstructionAddress2) ReadOriginalBytes(AntiFlinch::InstructionAddress2, AntiFlinch::origBytes2); if (AntiFlinch::InstructionAddress3) ReadOriginalBytes(AntiFlinch::InstructionAddress3, AntiFlinch::origBytes3); if (ActivityLoader::InstructionAddress) ReadOriginalBytes(ActivityLoader::InstructionAddress, ActivityLoader::origBytes); if (Mag999::InstructionAddress) ReadOriginalBytes(Mag999::InstructionAddress, Mag999::origBytes); }
+inline void PerformStartupAobScans(DWORD pid, uintptr_t moduleBaseAddress) {
+    if (moduleBaseAddress == 0) {
+        LogMessage("[-] PerformStartupAobScans: Invalid moduleBaseAddress (0).");
+        return;
+    }
+    auto ScanAndLog = [&](const char* featureName, const std::string& aobPattern, std::atomic<uintptr_t>& instructionAddress_atomic) {
+        uintptr_t found_addr = 0;
+        NTSTATUS status = DriverComm::aob_scan_info(pid, moduleBaseAddress, DEFAULT_SCAN_REGION_SIZE, aobPattern.c_str(), "", found_addr);
+        if(NT_SUCCESS(status) && found_addr != 0) {
+            instructionAddress_atomic.store(found_addr);
+        } else {
+            instructionAddress_atomic.store(0);
+            // LogMessageF("[-] PerformStartupAobScans: AOBScan failed for %s or not found. Status: 0x%lX", featureName, status); // Optional: log individual failures
+        }
+    };
+    ScanAndLog("Killaura", Killaura::AOB, Killaura::InstructionAddress); ScanAndLog("LocalPlayer", LocalPlayer::AOB, LocalPlayer::InstructionAddress); ScanAndLog("LocalPlayer Disable Gravity", LocalPlayer::disableGravAOB, LocalPlayer::disableGravAddress); ScanAndLog("ViewAngles", ViewAngles::AOB, ViewAngles::InstructionAddress); ScanAndLog("Ghostmode", Ghostmode::AOB, Ghostmode::InstructionAddress); ScanAndLog("Godmode", Godmode::AOB, Godmode::InstructionAddress); ScanAndLog("InfAmmo", InfAmmo::AOB, InfAmmo::InstructionAddress); ScanAndLog("dmgMult", dmgMult::AOB, dmgMult::InstructionAddress); ScanAndLog("RPM", RPM::AOB, RPM::InstructionAddress); ScanAndLog("NoRecoil", NoRecoil::AOB, NoRecoil::InstructionAddress); ScanAndLog("OHK", OHK::AOB, OHK::InstructionAddress); ScanAndLog("NoJoinAllies", NoJoinAllies::AOB, NoJoinAllies::InstructionAddress); ScanAndLog("NoTurnBack", NoTurnBack::AOB, NoTurnBack::InstructionAddress); ScanAndLog("InfSwordAmmo", InfSwordAmmo::AOB, InfSwordAmmo::InstructionAddress); ScanAndLog("SparrowAnywhere", SparrowAnywhere::AOB, SparrowAnywhere::InstructionAddress); ScanAndLog("InfStacks", InfStacks::AOB, InfStacks::InstructionAddress); ScanAndLog("NoRezTokens", NoRezTokens::AOB, NoRezTokens::InstructionAddress); ScanAndLog("InstaRespawn", InstaRespawn::AOB, InstaRespawn::InstructionAddress); ScanAndLog("RespawnAnywhere", RespawnAnywhere::AOB, RespawnAnywhere::InstructionAddress); ScanAndLog("ShootThru", ShootThru::AOB, ShootThru::InstructionAddress); ScanAndLog("Chams", Chams::AOB, Chams::InstructionAddress); ScanAndLog("AbilityCharge", AbilityCharge::AOB, AbilityCharge::InstructionAddress); ScanAndLog("ImmuneAura", ImmuneAura::AOB, ImmuneAura::InstructionAddress); ScanAndLog("IcarusDash", IcarusDash::AOB, IcarusDash::InstructionAddress); ScanAndLog("InstantInteract", InstantInteract::AOB, InstantInteract::InstructionAddress); ScanAndLog("InteractThruWalls1", InteractThruWalls::AOB1, InteractThruWalls::InstructionAddress1); ScanAndLog("InteractThruWalls2", InteractThruWalls::AOB2, InteractThruWalls::InstructionAddress2); ScanAndLog("GameSpeed", GameSpeed::AOB, GameSpeed::Address); ScanAndLog("LobbyCrasher", LobbyCrasher::AOB, LobbyCrasher::InstructionAddress); ScanAndLog("GSize", GSize::AOB, GSize::Address); ScanAndLog("Oxygen", Oxygen::AOB, Oxygen::InstructionAddress); ScanAndLog("InfSparrowBoost", InfSparrowBoost::AOB, InfSparrowBoost::InstructionAddress); ScanAndLog("InfBuffTimers", InfBuffTimers::AOB, InfBuffTimers::InstructionAddress); ScanAndLog("InfExoticBuffTimers", InfExoticBuffTimers::AOB, InfExoticBuffTimers::InstructionAddress); ScanAndLog("AntiFlinch1", AntiFlinch::AOB1, AntiFlinch::InstructionAddress1); ScanAndLog("AntiFlinch2", AntiFlinch::AOB2, AntiFlinch::InstructionAddress2); ScanAndLog("AntiFlinch3", AntiFlinch::AOB3, AntiFlinch::InstructionAddress3); ScanAndLog("ActivityLoader", ActivityLoader::AOB, ActivityLoader::InstructionAddress); ScanAndLog("Mag999", Mag999::AOB, Mag999::InstructionAddress); ScanAndLog("FOV", FOV::AOB, FOV::ptr);
+}
+
+template<size_t N>
+inline bool ReadOriginalBytes(std::atomic<uintptr_t>& address_atomic, BYTE(&origBytes_array)[N]) {
+    uintptr_t address = address_atomic.load();
+    if (address == 0) return false;
+    return NT_SUCCESS(DriverComm::read_memory_buffer(address, origBytes_array, N, nullptr));
+}
+
+inline void PerformStartupByteReads(DWORD pid, uintptr_t moduleBaseAddress) {
+    UNREFERENCED_PARAMETER(moduleBaseAddress); UNREFERENCED_PARAMETER(pid);
+    // Using .load() for checking the address before calling ReadOriginalBytes
+    if (Killaura::InstructionAddress.load() != 0) ReadOriginalBytes(Killaura::InstructionAddress, Killaura::origBytes);
+    if (LocalPlayer::InstructionAddress.load() != 0) ReadOriginalBytes(LocalPlayer::InstructionAddress, LocalPlayer::origBytes);
+    if (LocalPlayer::disableGravAddress.load() != 0) ReadOriginalBytes(LocalPlayer::disableGravAddress, LocalPlayer::disableGravOrigBytes);
+    if (ViewAngles::InstructionAddress.load() != 0) ReadOriginalBytes(ViewAngles::InstructionAddress, ViewAngles::origBytes);
+    if (Ghostmode::InstructionAddress.load() != 0) ReadOriginalBytes(Ghostmode::InstructionAddress, Ghostmode::origBytes);
+    if (Godmode::InstructionAddress.load() != 0) ReadOriginalBytes(Godmode::InstructionAddress, Godmode::origBytes);
+    if (InfAmmo::InstructionAddress.load() != 0) ReadOriginalBytes(InfAmmo::InstructionAddress, InfAmmo::origBytes);
+    if (dmgMult::InstructionAddress.load() != 0) ReadOriginalBytes(dmgMult::InstructionAddress, dmgMult::origBytes);
+    if (RPM::InstructionAddress.load() != 0) ReadOriginalBytes(RPM::InstructionAddress, RPM::origBytes);
+    if (NoRecoil::InstructionAddress.load() != 0) ReadOriginalBytes(NoRecoil::InstructionAddress, NoRecoil::origBytes);
+    if (OHK::InstructionAddress.load() != 0) ReadOriginalBytes(OHK::InstructionAddress, OHK::origBytes);
+    if (NoJoinAllies::InstructionAddress.load() != 0) ReadOriginalBytes(NoJoinAllies::InstructionAddress, NoJoinAllies::origBytes);
+    if (NoTurnBack::InstructionAddress.load() != 0) ReadOriginalBytes(NoTurnBack::InstructionAddress, NoTurnBack::origBytes);
+    if (InfSwordAmmo::InstructionAddress.load() != 0) ReadOriginalBytes(InfSwordAmmo::InstructionAddress, InfSwordAmmo::origBytes);
+    if (SparrowAnywhere::InstructionAddress.load() != 0) ReadOriginalBytes(SparrowAnywhere::InstructionAddress, SparrowAnywhere::origByte);
+    if (InfStacks::InstructionAddress.load() != 0) ReadOriginalBytes(InfStacks::InstructionAddress, InfStacks::origBytes);
+    if (NoRezTokens::InstructionAddress.load() != 0) ReadOriginalBytes(NoRezTokens::InstructionAddress, NoRezTokens::origByte);
+    if (InstaRespawn::InstructionAddress.load() != 0) ReadOriginalBytes(InstaRespawn::InstructionAddress, InstaRespawn::origBytes);
+    if (RespawnAnywhere::InstructionAddress.load() != 0) ReadOriginalBytes(RespawnAnywhere::InstructionAddress, RespawnAnywhere::origBytes);
+    if (ShootThru::InstructionAddress.load() != 0) ReadOriginalBytes(ShootThru::InstructionAddress, ShootThru::origBytes);
+    if (Chams::InstructionAddress.load() != 0) ReadOriginalBytes(Chams::InstructionAddress, Chams::origBytes);
+    if (AbilityCharge::InstructionAddress.load() != 0) ReadOriginalBytes(AbilityCharge::InstructionAddress, AbilityCharge::origBytes);
+    if (ImmuneAura::InstructionAddress.load() != 0) ReadOriginalBytes(ImmuneAura::InstructionAddress, ImmuneAura::origBytes);
+    if (IcarusDash::InstructionAddress.load() != 0) ReadOriginalBytes(IcarusDash::InstructionAddress, IcarusDash::origBytes);
+    if (InstantInteract::InstructionAddress.load() != 0) ReadOriginalBytes(InstantInteract::InstructionAddress, InstantInteract::origBytes);
+    if (InteractThruWalls::InstructionAddress1.load() != 0) ReadOriginalBytes(InteractThruWalls::InstructionAddress1, InteractThruWalls::origBytes1);
+    if (InteractThruWalls::InstructionAddress2.load() != 0) ReadOriginalBytes(InteractThruWalls::InstructionAddress2, InteractThruWalls::origBytes2);
+    if (LobbyCrasher::InstructionAddress.load() != 0) ReadOriginalBytes(LobbyCrasher::InstructionAddress, LobbyCrasher::origBytes);
+    if (Oxygen::InstructionAddress.load() != 0) ReadOriginalBytes(Oxygen::InstructionAddress, Oxygen::origBytes);
+    if (InfSparrowBoost::InstructionAddress.load() != 0) ReadOriginalBytes(InfSparrowBoost::InstructionAddress, InfSparrowBoost::origByte);
+    if (InfBuffTimers::InstructionAddress.load() != 0) ReadOriginalBytes(InfBuffTimers::InstructionAddress, InfBuffTimers::origBytes);
+    if (InfExoticBuffTimers::InstructionAddress.load() != 0) ReadOriginalBytes(InfExoticBuffTimers::InstructionAddress, InfExoticBuffTimers::origBytes);
+    if (AntiFlinch::InstructionAddress1.load() != 0) ReadOriginalBytes(AntiFlinch::InstructionAddress1, AntiFlinch::origBytes1);
+    if (AntiFlinch::InstructionAddress2.load() != 0) ReadOriginalBytes(AntiFlinch::InstructionAddress2, AntiFlinch::origBytes2);
+    if (AntiFlinch::InstructionAddress3.load() != 0) ReadOriginalBytes(AntiFlinch::InstructionAddress3, AntiFlinch::origBytes3);
+    if (ActivityLoader::InstructionAddress.load() != 0) ReadOriginalBytes(ActivityLoader::InstructionAddress, ActivityLoader::origBytes);
+    if (Mag999::InstructionAddress.load() != 0) ReadOriginalBytes(Mag999::InstructionAddress, Mag999::origBytes);
+}
 
 
 // Hook enabling functions


### PR DESCRIPTION
This commit introduces several enhancements:

1.  **KM-Ready Signal:** Implemented a more explicit ready signal from KM to UM. The KM now sets a flag in the SharedCommBlock after its discovery and attachment thread is fully initialized. The UM's InitializeStealthComm waits for this flag, improving handshake robustness.

2.  **Background AOB Scanning:** AOB scans during startup are now performed on a background thread in the GUI application. This prevents the UI from freezing and improves perceived startup performance. Feature addresses are now std::atomic, and UI elements update as scans complete.

3.  **Codecave Memory Management:** Implemented deallocation for codecave memory in the target process.
    - Added REQUEST_FREE_MEMORY command to KM.
    - StealthComm and DriverComm layers updated to support this.
    - Features using codecaves now call a release function when disabled, preventing memory leaks in the target process.

4.  **Error Code Propagation:** Improved error reporting in core layers.
    - StealthComm and DriverComm functions now primarily return NTSTATUS for more detailed error information, which is logged.
    - GUI layer integration was partially limited by tooling issues with Features.h, so it still relies on older error checking mechanisms, but lower-level diagnostics are improved.